### PR TITLE
Add bb tasks and github action to deploy to clojars

### DIFF
--- a/.github/workflows/clojars.yml
+++ b/.github/workflows/clojars.yml
@@ -1,0 +1,35 @@
+name: Clojure CI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Prepare java
+        uses: actions/setup-java@v1
+        with: { java-version: 1.11 }
+
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@10.0
+        with:
+          cli: latest
+          bb: latest
+
+      - name: Build jar
+        run: bb uber
+
+      - name: Deploy to clojars
+        env:
+          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+          CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+        run: bb deploy

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .clj-kondo/
 .cpcache/
 .lsp/
+target/

--- a/bb.edn
+++ b/bb.edn
@@ -1,1 +1,11 @@
-{:deps {com.escherize/huff {:local/root "."}}}
+{:deps {com.escherize/huff {:local/root "."}}
+ :tasks
+ {uber {:doc "Build uberjar"
+        :task (do
+                (println "Building uberjar...")
+                (clojure "-T:build jar"))}
+
+  deploy {:doc "Deploy to Clojars"
+          :task (do
+                  (println "Deploying to clojars")
+                  (clojure "-T:build deploy"))}}}

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,51 @@
+(ns build
+  (:require
+    [clojure.java.shell :refer [sh]]
+    [clojure.string :as str]
+    [clojure.tools.build.api :as b]
+    [org.corfield.build :as bb]))
+
+
+(defn git-tag
+  []
+  (let [tag (->> (sh "git" "tag") :out str/split-lines peek)]
+    (if (seq tag) tag "0.1-SNAPSHOT")))
+
+
+(def lib 'io.github.escherize/huff.git)
+(def main 'huff.core)
+(def version (git-tag))
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
+
+
+(defn clean
+  [_]
+  (b/delete {:path "target"}))
+
+
+(defn jar
+  [_]
+  (b/write-pom {:class-dir class-dir
+                :lib lib
+                :version version
+                :basis basis
+                :scm {:url "https://github.com/escherize/huff"
+                      :connection "scm:git:git://github.com/escherize/huff.git"
+                      :developerConnection "scm:git:ssh://git@github.com/escherize/huff.git"}
+                :src-dirs ["src"]})
+  (b/copy-dir {:src-dirs ["src" "resources"]
+               :target-dir class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file jar-file}))
+
+
+(defn deploy
+  "Deploy the JAR to Clojars."
+  [{:as opts}]
+  (-> opts
+      (assoc :lib lib
+             :version version
+             :main main)
+      (bb/deploy)))

--- a/build.clj
+++ b/build.clj
@@ -12,7 +12,7 @@
     (if (seq tag) tag "0.1-SNAPSHOT")))
 
 
-(def lib 'io.github.escherize/huff.git)
+(def lib 'io.github.escherize/huff)
 (def main 'huff.core)
 (def version (git-tag))
 (def class-dir "target/classes")

--- a/deps.edn
+++ b/deps.edn
@@ -4,4 +4,8 @@
                   :extra-deps  {hiccup/hiccup           {:mvn/version "1.0.5"}
                                 com.lambdaisland/hiccup {:mvn/version "0.0.25"}
                                 com.taoensso/tufte      {:mvn/version "2.4.5"}
-                                criterium/criterium     {:mvn/version "0.4.6"}}}}}
+                                criterium/criterium     {:mvn/version "0.4.6"}}}
+
+           :build {:ns-default build
+                   :deps {io.github.seancorfield/build-clj {:git/tag "v0.8.3" :git/sha "7ac1f8d"}
+                          io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}}}}}


### PR DESCRIPTION
Hi, thanks for the great library! I want to start using it in production on Datomic Ions, which doesn't allow to easily install libs from github (they use an outdated cli version, that only accepts :sha instead of :git/sha).

Anyway, it would greatly help if huff was on clojars, so I made everything to automatically deploy it to clojars on new tag. All you need to do is add `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` to your github actions secrets and create a new tag — and it will deploy.

I would really appreciate you merging it. Thanks!