### PR TITLE
add custom extensions to the beginning of the schema

### DIFF
--- a/src/huff2/extension.clj
+++ b/src/huff2/extension.clj
@@ -26,7 +26,10 @@
      (fn [element]
        ;; We want to add a branch to the hiccup branches.
        (if (hiccup-branches? element)
-         (conj element [node-name node-schema])
+         (vec (concat
+                (take 2 element)
+                [[node-name node-schema]]
+                (drop 2 element)))
          element))
      hiccup-schema)))
 

--- a/test/huff/extension_test.clj
+++ b/test/huff/extension_test.clj
@@ -14,6 +14,14 @@
     (is (= "<div><h1>I have 3 children.</h1></div>"
            (str (my-html [:div>h1 [:my/child-counter-tag "one" "two" "three"]]))))))
 
+(deftest eq-extension
+  (let [my-schema (h2e/add-schema-branch h/hiccup-schema :=)
+        _add-emitter (defmethod h/emit := [append! [_ [_ values]] opts]
+                       (apply append! values))
+        my-html (partial h/html (h2e/custom-fxns! my-schema))]
+    (is (= "<div><h1><img src=\"https://example.com/image.png\" /></h1></div>"
+           (str (my-html [:div>h1 [:= "<img src=\"https://example.com/image.png\" />"]]))))))
+
 (deftest catn-named-values-in-schema
   (let [my-schema (h2e/add-schema-branch
                     h/hiccup-schema


### PR DESCRIPTION
- this way extensions have priority.

Adds ability to support `:=` tag in userspace.

This was never hit before, because we only supported namespaced keywords as tag extensions.