### PR TITLE
Update malli to 0.18.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths   ["src"]
- :deps    {metosin/malli {:mvn/version "0.13.0"}}
+ :deps    {metosin/malli {:mvn/version "0.18.0"}}
  :aliases {:perf {:extra-paths ["perf" "perf_resources"]
                   :extra-deps  {hiccup/hiccup           {:mvn/version "1.0.5"}
                                 com.lambdaisland/hiccup {:mvn/version "0.0.33"}


### PR DESCRIPTION
These are the most immediate changes necessary to use the latest version of Malli.  

I don't think this is particularly good and I wouldn't merge it, but I wanted to start a discussion around how to get this updated since it's blocking some stuff in a personal project of mine. 

The biggest problem imo, is that the change in Malli's `m/parse` function leaks details into `emit` which wouldn't be an issue except for extensions.  Those are external and shouldn't break from this update.

I think the right approach is going to be to rework the parser and not use any of these changes here.

Whatever the situation, I'm open to feedback and interested in implementing a solution.