### PR TITLE
Call custom parser value beyond `component-node`

### DIFF
--- a/src/huff2/core.clj
+++ b/src/huff2/core.clj
@@ -98,7 +98,7 @@
     :else (str text)))
 
 (def ^:dynamic *escape?* true)
-(def ^:dynamic  *parser* (m/parser hiccup-schema))
+(def ^:dynamic  *parser* parser)
 
 (defn parse [hiccup]
   (*parser* hiccup))

--- a/test/huff/core2_test.clj
+++ b/test/huff/core2_test.clj
@@ -180,3 +180,18 @@
          (str (h/html [:div {:style {:width (-> 10 h/vmin)}}]))))
   (is (= "<div style=\"width:10vmax;\"></div>"
          (str (h/html [:div {:style {:width (-> 10 h/vmax)}}])))))
+
+(deftest custom-parser
+  (is (=
+       "<div><span>Hello world</span></div>"
+       (let [comp (fn []
+                    [:span "hi"])]
+         (str (h/html {:*parser (fn [node]
+                                  (if (= (first node) :span)
+                                    [:tag-node-no-attrs
+                                     {:tag :span
+                                      :children
+                                      [[:primative "Hello world"]]}]
+                                    (h/parser node)))}
+                      [:div
+                       [comp]]))))))


### PR DESCRIPTION
`emit` with `:component-node` always calls the default parser and not the one that's passed in. 

This adds `*parser*`, a dynamic var that is referenced in a `parse` fn to ensure the right fn is called.