### PR TITLE
fix test syntax

### DIFF
--- a/test/huff/hiccup22_test.clj
+++ b/test/huff/hiccup22_test.clj
@@ -205,7 +205,7 @@
   (testing "literals"
     (is (= "&lt;&gt;"
            (str (h/html "<>"))))
-    (is (= "&lt;&gt;" (str (h/html ^String "<>"))))
+    (is (= "&lt;&gt;" (str (h/html "<>"))))
     (is (= "1"
            (str (h/html 1))))
     (is (= "2"


### PR DESCRIPTION
Tests were not being loaded because some test was putting Metadata onto a string literal.
